### PR TITLE
Allow overriding already defined responses (work in progress)

### DIFF
--- a/test/e2e/proxy-response-overriding.js
+++ b/test/e2e/proxy-response-overriding.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var HttpBackend = require('../lib/http-backend-proxy');
+
+describe('Overriding responses', function(){
+
+  var angularVersion;
+  var urlSelectorFunctionsSupported;
+  var firstRun0 = true;
+
+  beforeEach(function () {
+
+    if(firstRun0){
+      firstRun0 = false;
+
+      browser.get('index.html');
+      element(by.id('version')).getText().then(function(version){
+        angularVersion = JSON.parse(version);
+        urlSelectorFunctionsSupported = angularVersion.major > 1 || angularVersion.minor > 2;
+      });
+    }
+
+  });
+
+  describe('Basic remotely configured GET call', function() {
+
+    var httpBackend;
+    var firstRun = true;
+
+    beforeEach(function() {
+
+      if(firstRun){
+        firstRun = false;
+
+        browser.get('index.html');
+
+        httpBackend = new HttpBackend(browser);
+        httpBackend.when('GET', '/remote').respond(200, {
+          msg: "You called /remote",
+        }, {'test-header': 'remote success'});
+
+        element(by.id('method')).sendKeys('GET');
+        element(by.id('url')).sendKeys('remote');
+        element(by.id('call')).click();
+
+        httpBackend.when('GET', '/remote').respond(200, {
+          msg: "A different response from /remote",
+        }, {'test-header': 'remote success again'});
+
+        element(by.id('call')).click();
+      }
+
+    });
+
+    it('should result in a response status of 200', function() {
+
+      expect(element(by.id('r-status')).getText()).toEqual('200');
+
+    });
+
+    it('should display altered response body', function() {
+
+      expect(element(by.id('r-data')).getText())
+        .toEqual('{"msg":"A different response from /remote"}');
+
+    });
+
+    it('should display altered response header', function() {
+
+      expect(element(by.id('r-headers')).getText())
+        .toEqual('{"test-header":"remote success again"}');
+
+    });
+
+  });
+});

--- a/test/lib/http-backend-proxy.js
+++ b/test/lib/http-backend-proxy.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+var crypto = require('crypto');
+
 var Proxy = function(browser, options){
 
   var DEFAULT_CONTEXT_FIELD_NAME = 'context';
@@ -37,6 +39,17 @@ var Proxy = function(browser, options){
     return function(){
 
       var whenJS = '$httpBackend.' + funcName + '(' + stringifyArgs(arguments) + ')';
+      var signature = md5(whenJS);
+
+      whenJS = [
+        '(function(){',
+        'window.httpBackendProxyRegistry = window.httpBackendProxyRegistry || {};',
+        'return typeof window.httpBackendProxyRegistry["' + signature + '"] == "undefined" ?',
+        'window.httpBackendProxyRegistry["' + signature + '"] = ' + whenJS,
+        ':',
+        'window.httpBackendProxyRegistry["' + signature + '"]',
+        '})()'
+      ].join('');
 
       return {
         respond: function() {
@@ -237,6 +250,10 @@ var Proxy = function(browser, options){
 
     return JSON.stringify(obj);
 
+  }
+
+  function md5(str){
+    return crypto.createHash('md5').update(str).digest('hex');
   }
 
 };

--- a/test/unit/buffering-spec.js
+++ b/test/unit/buffering-spec.js
@@ -156,7 +156,11 @@ describe('Buffered configuration', function(){
 
       it('should include all calls to the proxy in that single call', function () {
         expect(browser.executeScript.calls[0].args[0]).toContain(
-          '$httpBackend.whenGET("/url1").passThrough();\n$httpBackend.whenGET("/url2").passThrough();');
+          '$httpBackend.whenGET("/url1").passThrough();'
+        );
+        expect(browser.executeScript.calls[0].args[0]).toContain(
+          '$httpBackend.whenGET("/url2").passThrough();'
+        );
       });
 
       it('should pass the current data context to the browser', function () {

--- a/test/unit/context-passing-spec.js
+++ b/test/unit/context-passing-spec.js
@@ -93,8 +93,8 @@ describe('The Context Object', function(){
 
       proxy.whenGET('/someURL').respond(200);
 
-      expect(browser.executeScript.calls[0].args[0]).toContain(
-        '$httpBackend.alternate={};$httpBackend.whenGET("/someURL").respond(200);');
+      expect(browser.executeScript.calls[0].args[0]).toContain('$httpBackend.alternate={};');
+      expect(browser.executeScript.calls[0].args[0]).toContain('$httpBackend.whenGET("/someURL").respond(200);');
 
     });
 


### PR DESCRIPTION
Hi,

Proof of concept modification to allow overriding responses. I feel rather silly because only after finishing this I realized that context object solves my problem.. But hey.. For your consideration. If anyone is interested in this I could finish it up (unit test fail, e2e pass, includes demo of this new feature too).

What I wanted to achieve with this is:

```
describe('The page', function() {
  beforeEach(function() {
    proxy.when('GET', '/something').respond(200, {prop: "value"});
    proxy.when('GET', '/something/more').respond(200, {prop: "another value"});
    proxy.when('GET', '/something/else').respond(200, {prop: "yet another"});
  });

  it('shows everything neatly', function() {
    page.go(...);
    .... expectations ...
  });

  describe('when some things respond differently', function() {
    beforeEach(function() {
      proxy.when('GET', '/something/else').respond(404, {msg: "not found"});
    });

    it('does not show "else"', function() {
      page.go(...);
      ... expectations ... 
    });
  });
});
```

To achieve this I maintain a registry of $httpBackend mocks so I can alter responses later. This registry is indexed by md5 of mock arguments. When registering a new mock, injected JS code checks for existing mock and updates response if found or creates a new and registers it.

Does it make sense? Should I try to finish it up to something merge-to-mainline-worthy?

Cheers,
Tadas
