### PR TITLE
Fixed improper deferred API usage

### DIFF
--- a/test/lib/http-backend-proxy.js
+++ b/test/lib/http-backend-proxy.js
@@ -84,7 +84,7 @@ var Proxy = function(browser, options){
         return browser.executeScript(script);
       } else {
         var deferred = protractor.promise.defer();
-        deferred.promise.complete();
+        deferred.fulfill();
         return deferred.promise;
       }
     }


### PR DESCRIPTION
deferred.promise.complete is not actually a function. The correct way to resolve a promise is to call fulfill on its deferred