### PR TITLE
Fix tests in recent node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - 4.5
 
 before_script:
   - export DISPLAY=:99.0

--- a/test/unit/helpers/regular-expression-scenarios.js
+++ b/test/unit/helpers/regular-expression-scenarios.js
@@ -21,7 +21,7 @@ module.exports = [
         desc  : 'litterals with forward slashes'
     }, {
         regex : new RegExp('/a/path'),
-        output: 'new RegExp("/a/path")',
+        output: 'new RegExp("\\\\/a\\\\/path")',
         desc  : 'constructors with forward slashes'
     }, {
         regex : /'quoted'/,

--- a/test/unit/shortcut-methods-spec.js
+++ b/test/unit/shortcut-methods-spec.js
@@ -47,7 +47,7 @@ describe('Shortcut Method JavaScript Generation', function() {
         it('should generate the correct JavaScript when called with a url regex.', function() {
           methodUnderTest(new RegExp('/url')).passThrough();
           expect(browser.executeScript.calls[0].args[0]).toContain(
-            '$httpBackend.' + methodName + '(new RegExp("/url")).passThrough();');
+            '$httpBackend.' + methodName + '(new RegExp("\\\\/url")).passThrough();');
         });
 
         it('should generate the correct JavaScript when called with a url and headers', function() {
@@ -89,7 +89,7 @@ describe('Shortcut Method JavaScript Generation', function() {
         it('should generate the correct JavaScript when called with a url regex.', function() {
           methodUnderTest(new RegExp('/url')).passThrough();
           expect(browser.executeScript.calls[0].args[0]).toContain(
-            '$httpBackend.' + methodName + '(new RegExp("/url")).passThrough();');
+            '$httpBackend.' + methodName + '(new RegExp("\\\\/url")).passThrough();');
         });
 
         it('should generate the correct JavaScript when called with a url and data object.', function() {
@@ -138,7 +138,7 @@ describe('Shortcut Method JavaScript Generation', function() {
     it('should generate the correct JavaScript when called with a url regex.', function() {
       proxy.whenJSONP(new RegExp('/url')).passThrough();
       expect(browser.executeScript.calls[0].args[0]).toContain(
-        '$httpBackend.whenJSONP(new RegExp("/url")).passThrough();');
+        '$httpBackend.whenJSONP(new RegExp("\\\\/url")).passThrough();');
     });
 
   });


### PR DESCRIPTION
Seems like `JSON.stringify()` implementation have changed for RegExp objects in Node.js since the last build.
